### PR TITLE
Adapt to omniauth2

### DIFF
--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -37,10 +37,9 @@ module OmniAuth
       end
 
       def callback_url
-        # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
-        options[:callback_url] || (full_host + script_name + callback_path)
+        options[:callback_url] || (full_host + callback_path)
       end
-      
+
       uid { raw_info['userId'] }
 
       info do

--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -36,10 +36,6 @@ module OmniAuth
         super
       end
 
-      def callback_url
-        options[:callback_url] || (full_host + callback_path)
-      end
-
       uid { raw_info['userId'] }
 
       info do
@@ -79,7 +75,7 @@ module OmniAuth
       end
 
       def callback_url
-        full_host + script_name + callback_path
+        options[:callback_url] || (full_host + callback_path)
       end
 
       private

--- a/omniauth-line.gemspec
+++ b/omniauth-line.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'json', '>= 2.3.0'
-  s.add_dependency 'omniauth-oauth2', '~> 1.4'
-  s.add_dependency 'jwt', '~> 1.5'
-  s.add_development_dependency 'bundler', '~> 2.0'
+  s.add_dependency 'omniauth', '>= 2.0'
+  s.add_dependency 'omniauth-oauth2', '>= 1.4'
+  s.add_dependency 'jwt', '>= 2.2.0'
+  s.add_development_dependency 'bundler', '>= 2.0'
 end


### PR DESCRIPTION
ref. https://github.com/zquestz/omniauth-google-oauth2/issues/401

# やること
- omniauth バージョン2系に対応。
- 全体的にバージョン指定を `~>` ではなく `>=` で指定するように変更し、依存gemがほぼ仕様の変わらないバージョンアップを行った際にも問題なくなるように修正。

@oishi-kenko/rails-engineers レビューお願いします🙏