### PR TITLE
[Opus 4.8 (1M context)] fix: gemspec のファイル列挙を git ls-files から Dir.glob に変更

### DIFF
--- a/omniauth-line.gemspec
+++ b/omniauth-line.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |s|
   s.summary     = s.description
   s.license     = "MIT"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir.glob("**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) || f == ".git" || f.start_with?(".git/") }
+  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_dependency 'json', '>= 2.3.0'


### PR DESCRIPTION
[Opus 4.8 (1M context)]

## 概要

gemspec の `s.files` / `s.test_files` / `s.executables` を、`git ls-files` のシェル実行ではなく `Dir.glob` ベースのファイル列挙に置き換えます。

## 動機

現状の gemspec はファイル一覧を `git ls-files` の実行結果から生成しています。

```ruby
s.files       = `git ls-files`.split("\n")
s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
```

この方法は **gemspec を評価する時点で git の作業ツリー（`.git` メタデータ）が参照できること**を前提にしています。そのため、git メタデータが存在しない環境で gemspec が評価されると、`git ls-files` が次のように標準エラー出力へエラーを出し、空のリストを返します。

```
fatal: not a git repository: ...
```

このような状況は、たとえば次のケースで発生します。

- gem を別プロジェクトに `path:` / `git:` 依存として組み込み、`.git` を含まない形で配布・デプロイした場合
- `.git` ディレクトリを含めずにソースをコピーしたコンテナイメージ等の上で `bundle` を実行した場合

`s.files` が空になるだけで致命的な不具合にはなりませんが、`bundle` のセットアップ時に gemspec が評価されるたびにエラーメッセージが出力され、ログのノイズになります（`git ls-files` の呼び出し回数だけ出ます）。

## 変更内容

git に依存せず、ファイルシステムから直接列挙するように変更します。

```ruby
s.files       = Dir.glob("**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) || f == ".git" || f.start_with?(".git/") }
s.test_files  = s.files.grep(%r{^(test|spec|features)/})
s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
```

- gemspec 評価時のカレントディレクトリは gem のルートになる（元の `git ls-files` もそれを前提に動作していた）ため、相対パスの `Dir.glob` で同じ範囲を列挙できます。
- `.git` を除外しています。通常のクローンでは `.git` はディレクトリなので `File.directory?` で弾かれますが、submodule / git worktree として配置された場合は `.git` が gitlink **ファイル**になるため、`f == ".git"` でも明示的に除外しています。
- `test_files` / `executables` は `Dir.glob` 結果からの `grep` で導出するよう統一しました。

## 検証

クリーンなチェックアウトにおいて、新しい `Dir.glob` の結果が従来の `git ls-files` の出力と完全一致することを確認しています。

```sh
diff <(git ls-files | sort) \
     <(ruby -e 'puts Dir.glob(%q{**/*}, File::FNM_DOTMATCH).reject { |f| File.directory?(f) || f == %q{.git} || f.start_with?(%q{.git/}) }' | sort)
# 差分なし

ruby -e 's = Gem::Specification.load("omniauth-line.gemspec"); p s.files.size, s.test_files.size, s.executables'
# => 9, 2, []
```

git メタデータの無い環境でも `git ls-files` を呼ばなくなるため、`fatal: not a git repository` は出力されなくなります。
